### PR TITLE
fix gpgkey for epel EL8

### DIFF
--- a/data/RedHat/CentOS/common.yaml
+++ b/data/RedHat/CentOS/common.yaml
@@ -6,4 +6,4 @@ icinga::repos:
     baseurl: 'https://download.fedoraproject.org/pub/epel/%{facts.os.release.major}/$basearch'
     enabled: 0
     gpgcheck: 1
-    gpgkey: https://fedoraproject.org/static/352C64E5.txt
+    gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-%{facts.os.release.major}

--- a/data/RedHat/OracleLinux/common.yaml
+++ b/data/RedHat/OracleLinux/common.yaml
@@ -6,4 +6,4 @@ icinga::repos:
     baseurl: 'https://download.fedoraproject.org/pub/epel/%{facts.os.release.major}/$basearch'
     enabled: 0
     gpgcheck: 1
-    gpgkey: https://fedoraproject.org/static/352C64E5.txt
+    gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-%{facts.os.release.major}

--- a/data/RedHat/RedHat/common.yaml
+++ b/data/RedHat/RedHat/common.yaml
@@ -6,4 +6,4 @@ icinga::repos:
     baseurl: 'https://download.fedoraproject.org/pub/epel/%{facts.os.release.major}/$basearch'
     enabled: 0
     gpgcheck: 1
-    gpgkey: https://fedoraproject.org/static/352C64E5.txt
+    gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-%{facts.os.release.major}

--- a/data/RedHat/Scientific/common.yaml
+++ b/data/RedHat/Scientific/common.yaml
@@ -6,4 +6,4 @@ icinga::repos:
     baseurl: 'https://download.fedoraproject.org/pub/epel/%{facts.os.release.major}/$basearch'
     enabled: 0
     gpgcheck: 1
-    gpgkey: https://fedoraproject.org/static/352C64E5.txt
+    gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-%{facts.os.release.major}


### PR DESCRIPTION
GPG key for EL8 changed, use dedicated gpgkeys (major release) for epel.