### PR TITLE
Centos director install method

### DIFF
--- a/data/RedHat/common.yaml
+++ b/data/RedHat/common.yaml
@@ -32,3 +32,4 @@ icinga::repos:
     enabled: 1
     gpgcheck: 1
     gpgkey: https://packages.netways.de/netways-repo.asc
+icinga::web::director::install_method: git

--- a/manifests/web/director.pp
+++ b/manifests/web/director.pp
@@ -40,6 +40,9 @@
 # @param [String] api_pass
 #   Icinga 2 API password.
 #
+# @param [Enum['git', 'package', 'none']] install_method
+#   Install methods are `git`, `package` and `none` is supported as installation method.
+#
 class icinga::web::director(
   String                                 $db_pass,
   String                                 $api_pass,
@@ -54,6 +57,7 @@ class icinga::web::director(
   Boolean                                $manage_database = false,
   Stdlib::Host                           $api_host        = 'localhost',
   String                                 $api_user        = 'director',
+  Enum['git', 'package', 'none']         $install_method  = 'package',
 ) {
 
   icinga::prepare_web('Director')
@@ -90,7 +94,7 @@ class icinga::web::director(
   }
 
   class { 'icingaweb2::module::director':
-    install_method => 'package',
+    install_method => $install_method,
     db_type        => $db_type,
     db_host        => $_db_host,
     db_name        => $db_name,
@@ -106,7 +110,7 @@ class icinga::web::director(
   }
 
   class { 'icingaweb2::module::fileshipper':
-    install_method   => 'package',
+    install_method   => $install_method,
   }
 
   service { 'icinga-director':

--- a/manifests/web/director.pp
+++ b/manifests/web/director.pp
@@ -113,10 +113,9 @@ class icinga::web::director(
     install_method   => $install_method,
   }
 
-  service { 'icinga-director':
-    ensure  => $service_ensure,
-    enable  => $service_enable,
-    require => Class['icingaweb2::module::director'],
+  class { 'icingaweb2::module::director::service':
+    ensure => $service_ensure,
+    enable => $service_enable,
   }
 
 }


### PR DESCRIPTION
The package was not found during installation on a CentOS 7 system. With the adjustment, `git` is now used in the case of RHEL systems. `packages` will still be used as the default.

```
Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install icingaweb2-module-fileshipper' returned 1: Error: Nothing to do
Error: /Stage[main]/Icingaweb2::Module::Fileshipper/Icingaweb2::Module[fileshipper]/Package[icingaweb2-module-fileshipper]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install icingaweb2-module-fileshipper' returned 1: Error: Nothing to do
Error: Execution of '/usr/bin/yum -d 0 -e 0 -y install icingaweb2-module-director' returned 1: Error: Nothing to do
Error: /Stage[main]/Icingaweb2::Module::Director/Icingaweb2::Module[director]/Package[icingaweb2-module-director]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/yum -d 0 -e 0 -y install icingaweb2-module-director' returned 1: Error: Nothing to do
Notice: /Stage[main]/Icinga::Web::Director/Service[icinga-director]: Dependency Package[icingaweb2-module-director] has failures: true
Warning: /Stage[main]/Icinga::Web::Director/Service[icinga-director]: Skipping because of failed dependencies
```