### PR TITLE
Install icingaweb2 model pdfexport by default

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -152,7 +152,7 @@ class icinga::web (
   -> Class['apache']
   -> Class['icingaweb2']
 
-  package { 'icingaweb2':
+  package { ['icingaweb2', 'icingaweb2-module-pdfexport']:
     ensure => installed,
   }
 


### PR DESCRIPTION
But as package only, so that the config isn't done by the module.